### PR TITLE
Explain moodle plugin CI

### DIFF
--- a/enhanced-moodle-ci.yml
+++ b/enhanced-moodle-ci.yml
@@ -1,0 +1,160 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PHP 7.4 combinations (if supporting older Moodle)
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+            extensions: mbstring, xml, intl, gd, curl, zip, pgsql
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+          
+          # PHP 8.0 combinations
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+            extensions: mbstring, xml, intl, gd, curl, zip, pgsql
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+          
+          # PHP 8.1 combinations
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+            extensions: mbstring, xml, intl, gd, curl, zip, pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+
+          # Add newer versions if your plugin supports them
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: pgsql
+            extensions: mbstring, xml, intl, gd, curl, zip, pgsql
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: mariadb
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000, max_execution_time=300, memory_limit=512M
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint ./plugin
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcpd ./plugin
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd ./plugin
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0 ./plugin
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0 ./plugin
+
+      - name: Validating
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci validate ./plugin
+
+      - name: Check upgrade savepoints
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci savepoints ./plugin
+
+      - name: Mustache Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci mustache ./plugin
+
+      - name: Grunt
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0 ./plugin
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning ./plugin
+
+      - name: Behat features
+        id: behat
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci behat --profile chrome --scss-deprecations ./plugin
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (PHP ${{ matrix.php }}, ${{ matrix.moodle-branch }}, ${{ matrix.database }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Mark cancelled jobs as failed
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/fixed-moodle-ci.yml
+++ b/fixed-moodle-ci.yml
@@ -1,0 +1,145 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: 'postgres'
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+      mariadb:
+        image: mariadb:10
+        env:
+          MYSQL_USER: 'root'
+          MYSQL_ALLOW_EMPTY_PASSWORD: "true"
+          MYSQL_CHARACTER_SET_SERVER: "utf8mb4"
+          MYSQL_COLLATION_SERVER: "utf8mb4_unicode_ci"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval 10s --health-timeout 5s --health-retries 3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PHP 7.4 combinations
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+            extensions: mbstring, xml, intl, gd, curl, zip, pgsql
+          - php: '7.4'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+          
+          # PHP 8.0 combinations
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+            extensions: mbstring, xml, intl, gd, curl, zip, pgsql
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+          
+          # PHP 8.1 combinations
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: pgsql
+            extensions: mbstring, xml, intl, gd, curl, zip, pgsql
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mariadb
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000, max_execution_time=300, memory_limit=512M
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint ./plugin
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd ./plugin
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0 ./plugin
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0 ./plugin
+
+      - name: Validating
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci validate ./plugin
+
+      - name: Check upgrade savepoints
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci savepoints ./plugin
+
+      - name: Mustache Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci mustache ./plugin
+
+      - name: Grunt
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0 ./plugin
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning ./plugin
+
+      - name: Behat features
+        id: behat
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci behat --profile chrome --scss-deprecations ./plugin
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (PHP ${{ matrix.php }}, ${{ matrix.moodle-branch }}, ${{ matrix.database }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Mark cancelled jobs as failed
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/improved-moodle-ci.yml
+++ b/improved-moodle-ci.yml
@@ -1,0 +1,133 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+        moodle-branch: ['MOODLE_401_STABLE', 'MOODLE_403_STABLE', 'MOODLE_404_STABLE']
+        database: [mysqli]
+        include:
+          - php: '8.3'
+            moodle-branch: 'main'
+            database: mysqli
+        exclude:
+          # Exclude incompatible combinations if needed
+          - php: '8.1'
+            moodle-branch: 'main'
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, xml, intl, gd, curl, zip, mysqli, pgsql
+          ini-values: max_input_vars=5000, max_execution_time=300, memory_limit=512M
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: |
+          moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1 --db-user=root --db-pass=root
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint ./plugin
+
+      - name: PHP Copy/Paste Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcpd ./plugin
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd ./plugin
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0 ./plugin
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0 ./plugin
+
+      - name: Validating
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci validate ./plugin
+
+      - name: Check upgrade savepoints
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci savepoints ./plugin
+
+      - name: Mustache Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci mustache ./plugin
+
+      - name: Grunt
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0 ./plugin
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning ./plugin
+
+      - name: Behat features
+        id: behat
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci behat --profile chrome --scss-deprecations ./plugin
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (${{ matrix.php }}-${{ matrix.moodle-branch }}-${{ matrix.database }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Mark cancelled jobs as failed
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/moodle-ci-explanation.md
+++ b/moodle-ci-explanation.md
@@ -1,0 +1,219 @@
+# Moodle CI: Comprehensive Guide
+
+## What is Moodle CI?
+
+Moodle CI (Continuous Integration) is a comprehensive testing and code analysis toolkit designed specifically for Moodle plugin development. It facilitates automated testing and code quality checks for Moodle plugins in various CI environments like GitHub Actions and Travis CI.
+
+## Key Components
+
+### 1. Moodle Plugin CI (moodle-plugin-ci)
+- **Repository**: https://github.com/moodlehq/moodle-plugin-ci
+- **Documentation**: https://moodlehq.github.io/moodle-plugin-ci/
+- **Purpose**: Main tool that orchestrates testing and code analysis
+- **Current Version**: 4.x (requires PHP 7.4+ and Moodle 3.8.3+)
+
+### 2. Moodle CI Runner (moodle-ci-runner)
+- **Repository**: https://github.com/moodlehq/moodle-ci-runner
+- **Purpose**: Docker-based test runner for consistent CI environment
+- **Features**: Modular design with jobs, modules, and stages
+
+### 3. Catalyst Moodle Workflows
+- **Repository**: https://github.com/catalyst/catalyst-moodle-workflows
+- **Purpose**: Reusable GitHub Actions workflows for Moodle plugins
+- **Features**: Simplified CI setup with pre-configured workflows
+
+## Supported Testing Frameworks and Tools
+
+Moodle CI supports the following testing and analysis tools:
+
+### Testing Frameworks
+- **PHPUnit**: Unit testing framework for PHP
+- **Behat**: Behavior-driven development testing
+
+### Code Analysis Tools
+- **Moodle Code Checker**: Ensures code follows Moodle coding standards
+- **Moodle PHPdoc check**: Validates PHPdoc documentation
+- **Mustache Linting**: Checks Mustache template syntax
+- **Grunt tasks**: JavaScript/CSS build tasks
+- **PHP Linting**: Basic PHP syntax checking
+- **PHP Copy/Paste Detector** (DEPRECATED): Detects code duplication
+- **PHP Mess Detector**: Identifies potential code quality issues
+
+## How It Works
+
+### 1. Automation Benefits
+- **Saves Time**: Eliminates manual testing setup for every code change
+- **Consistency**: Ensures all tests run the same way every time
+- **Pull Request Safety**: Provides confidence when accepting contributions
+- **Multi-Environment Testing**: Tests against multiple PHP versions, databases, and Moodle versions
+
+### 2. CI Integration
+- **GitHub Actions**: Primary supported CI platform
+- **Travis CI**: Legacy support (deprecated as of v4.5.8, will be removed in v5.0.0)
+- **Other CI Services**: Community contributions for other platforms
+
+## Getting Started
+
+### GitHub Actions Setup
+
+1. **Copy Configuration File**
+   ```bash
+   # Copy the template to your plugin repository
+   cp gha.dist.yml .github/workflows/moodle-ci.yml
+   ```
+
+2. **Configure Your Plugin**
+   - Ensure your plugin has a `version.php` file
+   - Define `$plugin->component` in version.php
+   - Set supported Moodle versions in `$plugin->supported`
+
+3. **Basic Workflow Example**
+   ```yaml
+   name: ci
+   on: [push, pull_request]
+   
+   jobs:
+     ci:
+       uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+       with:
+         # Optional: disable specific checks
+         disable_behat: true
+         disable_grunt: true
+   ```
+
+### Local Development Usage
+
+You can also run Moodle CI locally for development:
+
+```bash
+# Install via Composer
+php composer.phar create-project moodlehq/moodle-plugin-ci ../moodle-plugin-ci ^4
+
+# Run specific checks
+../moodle-plugin-ci/bin/moodle-plugin-ci mustache ./mod/forum/
+../moodle-plugin-ci/bin/moodle-plugin-ci phpunit ./mod/forum/
+```
+
+## Key Features
+
+### 1. Version Matrix Testing
+- Tests against multiple Moodle versions automatically
+- Supports testing from Moodle 3.8.3 to latest development version
+- Configurable via `$plugin->supported` in version.php
+
+### 2. Database Support
+- PostgreSQL (default)
+- MySQL/MariaDB
+- Oracle
+- Microsoft SQL Server
+- SQLite
+
+### 3. Browser Testing (Behat)
+- Chrome (default)
+- Firefox
+- Headless mode support
+- Mobile app testing support
+
+### 4. Code Quality Checks
+- **PHP CodeSniffer**: Enforces Moodle coding standards
+- **PHPdoc Validation**: Ensures proper documentation
+- **Mustache Linting**: Template validation
+- **JavaScript/CSS Linting**: Via Grunt tasks
+
+## Advanced Configuration
+
+### Customization Options
+```yaml
+with:
+  codechecker_max_warnings: 0  # Fail on warnings
+  extra_plugin_runners: 'moodle-plugin-ci add-plugin catalyst/moodle-local_aws'
+  disable_behat: true
+  disable_phpdoc: true
+  disable_phpcs: true
+  disable_phplint: true
+  disable_phpunit: true
+  disable_grunt: true
+  disable_mustache: true
+  min_php: '7.4'
+  ignore_paths: 'vendor,node_modules'
+```
+
+### Dependencies Management
+```yaml
+extra_plugin_runners:
+  moodle-plugin-ci add-plugin danmarsden/moodle-mod_attendance --branch MOODLE_401_STABLE
+```
+
+## Historical Context
+
+### Evolution
+- **Original Creator**: MoodleRooms/Blackboard
+- **Current Maintainer**: Moodle HQ (since 2020)
+- **Key Contributors**: Mark Nielsen, Eloy Lafuente, Tim Hunt, and many others
+
+### Version History
+- **Version 1-3**: Legacy versions (no longer maintained)
+- **Version 4**: Current version with modern PHP and Moodle support
+- **Version 5**: Planned future version (will remove Travis CI support)
+
+## Related Tools
+
+### 1. Moodle Code Checker (local_codechecker)
+- **Repository**: https://github.com/moodlehq/moodle-local_codechecker
+- **Purpose**: Web UI for running code style checks
+- **Integration**: Used by moodle-plugin-ci for code validation
+
+### 2. Moodle PHPdoc Checker (local_moodlecheck)
+- **Repository**: https://github.com/moodlehq/moodle-local_moodlecheck
+- **Purpose**: Validates PHPdoc documentation style
+- **Status**: Being deprecated in favor of moodle-cs integration
+
+### 3. Moodle CS (Coding Standards)
+- **Repository**: https://github.com/moodlehq/moodle-cs
+- **Purpose**: Modern PHP CodeSniffer rules for Moodle
+- **Integration**: Used by code checker tools
+
+## Best Practices
+
+### 1. CI Configuration
+- Use the latest version of moodle-plugin-ci
+- Configure appropriate PHP and Moodle version ranges
+- Enable all relevant checks for your plugin type
+- Add CI status badges to your README
+
+### 2. Code Quality
+- Write comprehensive PHPUnit tests
+- Include Behat tests for user interactions
+- Follow Moodle coding standards consistently
+- Document your code with proper PHPdoc
+
+### 3. Maintenance
+- Keep your CI configuration updated
+- Monitor test results regularly
+- Fix failing tests promptly
+- Update dependencies when new versions are available
+
+## Troubleshooting
+
+### Common Issues
+1. **Stale Grunt Files**: Rebuild on the highest supported Moodle version
+2. **Database Compatibility**: Test against all supported database types
+3. **PHP Version Conflicts**: Ensure compatibility across PHP versions
+4. **Memory Limits**: Increase memory limits for large test suites
+
+### Getting Help
+- **Documentation**: https://moodlehq.github.io/moodle-plugin-ci/
+- **Issues**: Report bugs on GitHub repositories
+- **Community**: Moodle developer forums and community channels
+
+## Conclusion
+
+Moodle CI is an essential tool for maintaining high-quality Moodle plugins. It provides comprehensive testing and code analysis capabilities that help developers:
+
+- Maintain code quality standards
+- Ensure compatibility across Moodle versions
+- Automate testing processes
+- Collaborate more effectively
+- Deliver reliable plugins to the Moodle community
+
+By implementing Moodle CI in your plugin development workflow, you can significantly improve code quality, reduce bugs, and streamline the development process.

--- a/mysql-only-moodle-ci.yml
+++ b/mysql-only-moodle-ci.yml
@@ -1,0 +1,126 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Primary target - PHP 8.3 + MySQL 8.4 + Latest supported Moodle
+          - php: '8.3'
+            moodle-branch: 'MOODLE_404_STABLE'
+            database: mysqli
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+            primary: true
+          
+          # Optional: Test against other PHP versions if you want broader compatibility
+          - php: '8.2'
+            moodle-branch: 'MOODLE_403_STABLE'
+            database: mysqli
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+            primary: false
+            
+          - php: '8.1'
+            moodle-branch: 'MOODLE_401_STABLE'
+            database: mysqli
+            extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+            primary: false
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ matrix.extensions }}
+          ini-values: max_input_vars=5000, max_execution_time=300, memory_limit=512M
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1 --db-user=root --db-pass=root
+        env:
+          DB: ${{ matrix.database }}
+          MOODLE_BRANCH: ${{ matrix.moodle-branch }}
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint ./plugin
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd ./plugin
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0 ./plugin
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0 ./plugin
+
+      - name: Validating
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci validate ./plugin
+
+      - name: Check upgrade savepoints
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci savepoints ./plugin
+
+      - name: Mustache Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci mustache ./plugin
+
+      - name: Grunt
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0 ./plugin
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning ./plugin
+
+      - name: Behat features
+        id: behat
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci behat --profile chrome --scss-deprecations ./plugin
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump (PHP ${{ matrix.php }}, ${{ matrix.moodle-branch }})
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Mark cancelled jobs as failed
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/php83-only-moodle-ci.yml
+++ b/php83-only-moodle-ci.yml
@@ -1,0 +1,102 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: test
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+        with:
+          path: plugin
+
+      - name: Setup PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: mbstring, xml, intl, gd, curl, zip, mysqli
+          ini-values: max_input_vars=5000, max_execution_time=300, memory_limit=512M
+          coverage: none
+
+      - name: Initialise moodle-plugin-ci
+        run: |
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
+          echo $(cd ci/bin; pwd) >> $GITHUB_PATH
+          echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
+          sudo locale-gen en_AU.UTF-8
+          echo "NVM_DIR=$HOME/.nvm" >> $GITHUB_ENV
+
+      - name: Install moodle-plugin-ci
+        run: moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1 --db-user=root --db-pass=root
+        env:
+          DB: mysqli
+          MOODLE_BRANCH: MOODLE_404_STABLE  # Change to your target Moodle version
+
+      - name: PHP Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phplint ./plugin
+
+      - name: PHP Mess Detector
+        continue-on-error: true
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpmd ./plugin
+
+      - name: Moodle Code Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpcs --max-warnings 0 ./plugin
+
+      - name: Moodle PHPDoc Checker
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpdoc --max-warnings 0 ./plugin
+
+      - name: Validating
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci validate ./plugin
+
+      - name: Check upgrade savepoints
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci savepoints ./plugin
+
+      - name: Mustache Lint
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci mustache ./plugin
+
+      - name: Grunt
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci grunt --max-lint-warnings 0 ./plugin
+
+      - name: PHPUnit tests
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci phpunit --fail-on-warning ./plugin
+
+      - name: Behat features
+        id: behat
+        if: ${{ !cancelled() }}
+        run: moodle-plugin-ci behat --profile chrome --scss-deprecations ./plugin
+
+      - name: Upload Behat Faildump
+        if: ${{ failure() && steps.behat.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Behat Faildump
+          path: ${{ github.workspace }}/moodledata/behat_dump
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Mark cancelled jobs as failed
+        if: ${{ cancelled() }}
+        run: exit 1

--- a/simplified-moodle-ci.yml
+++ b/simplified-moodle-ci.yml
@@ -1,0 +1,27 @@
+name: Moodle Plugin CI
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main
+    with:
+      # Configure based on your plugin's version.php $plugin->supported
+      # This will automatically test against multiple PHP and Moodle versions
+      
+      # Optional: Disable specific checks if not needed
+      # disable_behat: true
+      # disable_grunt: true
+      # disable_phpdoc: true
+      
+      # Optional: Set maximum warnings (0 = fail on any warning)
+      codechecker_max_warnings: 0
+      
+      # Optional: Add extra plugins your plugin depends on
+      # extra_plugin_runners: 'moodle-plugin-ci add-plugin catalyst/moodle-local_aws'
+      
+      # Optional: Set minimum PHP version
+      min_php: '8.1'
+      
+      # Optional: Ignore specific paths
+      ignore_paths: 'vendor,node_modules,tests/fixtures'


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a Moodle CI configuration tailored for PHP 8.3 and MySQL 8.4.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This configuration ensures the plugin is tested against the specific production environment, which includes custom MySQL queries that may not be compatible with other database types like PostgreSQL or MariaDB.