### PR TITLE
Add initial implementation of local test plugin

### DIFF
--- a/local/testplugin/README.md
+++ b/local/testplugin/README.md
@@ -1,0 +1,47 @@
+# Test Plugin (local_testplugin)
+
+A simple test plugin for Moodle to test CI/CD workflows.
+
+## Features
+
+- Basic plugin structure
+- Settings page
+- Simple functionality demonstration
+- No PHPUnit tests (as requested)
+
+## Installation
+
+1. Copy the plugin to `local/testplugin/`
+2. Visit Site Administration to complete the installation
+3. Configure settings under Site Administration > Plugins > Local plugins > Test Plugin
+
+## Usage
+
+- Access the plugin at `/local/testplugin/index.php`
+- Configure settings in Site Administration
+- View plugin information and status
+
+## Purpose
+
+This plugin is designed for testing:
+- CI/CD workflows
+- Plugin detection systems
+- Deployment processes
+- Code quality checks
+
+## Files Structure
+
+```
+local/testplugin/
+├── version.php          # Plugin version and metadata
+├── lang/en/local_testplugin.php  # Language strings
+├── lib.php              # Library functions
+├── index.php            # Main plugin page
+├── settings.php         # Admin settings
+├── db/access.php        # Capability definitions
+└── README.md            # This file
+```
+
+## License
+
+GPL v3 or later

--- a/local/testplugin/db/access.php
+++ b/local/testplugin/db/access.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Capability definitions for local_testplugin
+ *
+ * @package    local_testplugin
+ * @copyright  2025 Your Name
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$capabilities = [
+    'local/testplugin:view' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+            'coursecreator' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'teacher' => CAP_ALLOW,
+        ],
+    ],
+];

--- a/local/testplugin/index.php
+++ b/local/testplugin/index.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Test plugin main page
+ *
+ * @package    local_testplugin
+ * @copyright  2025 Your Name
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once('../../config.php');
+require_once($CFG->libdir . '/adminlib.php');
+
+require_login();
+$context = context_system::instance();
+require_capability('moodle/site:config', $context);
+
+$PAGE->set_url('/local/testplugin/index.php');
+$PAGE->set_context($context);
+$PAGE->set_title(get_string('pluginname', 'local_testplugin'));
+$PAGE->set_heading(get_string('pluginname', 'local_testplugin'));
+
+echo $OUTPUT->header();
+
+echo html_writer::tag('h2', get_string('welcome', 'local_testplugin'));
+echo html_writer::tag('p', get_string('description', 'local_testplugin'));
+
+// Display plugin status.
+if (local_testplugin_is_enabled()) {
+    echo $OUTPUT->notification(get_string('enabled', 'local_testplugin'), 'success');
+} else {
+    echo $OUTPUT->notification('Plugin is disabled', 'warning');
+}
+
+// Simple test functionality.
+echo html_writer::start_tag('div', ['class' => 'testplugin-content']);
+echo html_writer::tag('h3', 'Plugin Information');
+echo html_writer::start_tag('ul');
+echo html_writer::tag('li', 'Plugin Name: ' . get_string('pluginname', 'local_testplugin'));
+echo html_writer::tag('li', 'Version: 1.0.0');
+echo html_writer::tag('li', 'Status: ' . (local_testplugin_is_enabled() ? 'Enabled' : 'Disabled'));
+echo html_writer::tag('li', 'Current Time: ' . date('Y-m-d H:i:s'));
+echo html_writer::end_tag('ul');
+echo html_writer::end_tag('div');
+
+echo $OUTPUT->footer();

--- a/local/testplugin/lang/en/local_testplugin.php
+++ b/local/testplugin/lang/en/local_testplugin.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Language strings for local_testplugin
+ *
+ * @package    local_testplugin
+ * @copyright  2025 Your Name
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['description'] = 'This is a simple test plugin for testing CI/CD workflows.';
+$string['enabled'] = 'Enable test plugin';
+$string['enabled_desc'] = 'Enable or disable the test plugin functionality.';
+$string['pluginname'] = 'Test Plugin';
+$string['settings'] = 'Test Plugin Settings';
+$string['testplugin:view'] = 'View test plugin';
+$string['welcome'] = 'Welcome to Test Plugin';

--- a/local/testplugin/lib.php
+++ b/local/testplugin/lib.php
@@ -1,0 +1,58 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Library functions for local_testplugin
+ *
+ * @package    local_testplugin
+ * @copyright  2025 Your Name
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+// Library functions - no direct access check needed as this file only contains function definitions.
+
+/**
+ * Get plugin welcome message
+ *
+ * @return string Welcome message
+ */
+function local_testplugin_get_welcome_message() {
+    return get_string('welcome', 'local_testplugin');
+}
+
+/**
+ * Check if plugin is enabled
+ *
+ * @return bool True if enabled
+ */
+function local_testplugin_is_enabled() {
+    return get_config('local_testplugin', 'enabled');
+}
+
+/**
+ * Initialize plugin
+ *
+ * @return void
+ */
+function local_testplugin_init() {
+    // Plugin initialization code here.
+    if (local_testplugin_is_enabled()) {
+        // Set default configuration values if not already set.
+        if (get_config('local_testplugin', 'initialized') === false) {
+            set_config('initialized', true, 'local_testplugin');
+        }
+    }
+}

--- a/local/testplugin/settings.php
+++ b/local/testplugin/settings.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Settings for local_testplugin
+ *
+ * @package    local_testplugin
+ * @copyright  2025 Your Name
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+if ($hassiteconfig) {
+    $settings = new admin_settingpage('local_testplugin', get_string('pluginname', 'local_testplugin'));
+
+    // Enable/disable setting.
+    $settings->add(new admin_setting_configcheckbox(
+        'local_testplugin/enabled',
+        get_string('enabled', 'local_testplugin'),
+        get_string('enabled_desc', 'local_testplugin'),
+        1
+    ));
+
+    $ADMIN->add('localplugins', $settings);
+}

--- a/local/testplugin/version.php
+++ b/local/testplugin/version.php
@@ -1,0 +1,31 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Version information for local_testplugin
+ *
+ * @package    local_testplugin
+ * @copyright  2025 Your Name
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$plugin->component = 'local_testplugin';
+$plugin->version = 2025010100;
+$plugin->requires = 2023100900; // Moodle 4.3.
+$plugin->maturity = MATURITY_STABLE;
+$plugin->release = '1.0.0';


### PR DESCRIPTION
- Created the basic structure for a new Moodle local plugin named 'Test Plugin'.
- Implemented main plugin page (index.php) with user notifications and plugin status display.
- Added library functions for welcome message and plugin status checks in lib.php.
- Defined plugin settings and capabilities in settings.php and access.php respectively.
- Included versioning information in version.php and language strings in lang/en/local_testplugin.php.
- Provided a README.md for installation and usage instructions.